### PR TITLE
bug: match accepts regexp

### DIFF
--- a/lib/helpers/lock-directory.js
+++ b/lib/helpers/lock-directory.js
@@ -2,7 +2,7 @@ module.exports = function () {
   let paths = [...arguments];
   return new Promise((reslove, reject) => {
     paths.forEach((path, i) => {
-      if (path.match('../')) {
+      if (path.includes('../')) {
         reject('can\'t access directories above base dir');
       }
     });


### PR DESCRIPTION
`match accepts regexp https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match

So any path will match the `../` regexp